### PR TITLE
Remove debug output of created dataframes introduced in 1.0.2

### DIFF
--- a/src/twelvedata/mixins.py
+++ b/src/twelvedata/mixins.py
@@ -61,7 +61,6 @@ class AsPandasMixin(object):
 
     @staticmethod
     def create_basic_df(data, pd, index_column="datetime", **kwargs):
-        print(len(data), data)
         df = convert_collection_to_pandas(data, **kwargs)
         df = df.set_index(index_column)
         df.index = pd.to_datetime(df.index, infer_datetime_format=True)


### PR DESCRIPTION
Latest update is causing output whenever a dataframe is put together with the create_basic_df call