### PR TITLE
Allow user to control requests session

### DIFF
--- a/src/twelvedata/http_client.py
+++ b/src/twelvedata/http_client.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-import requests
+from requests import Session
 from json import JSONDecodeError
 
 from .exceptions import (
@@ -16,6 +16,7 @@ __all__ = ("DefaultHttpClient",)
 class DefaultHttpClient(object):
     def __init__(self, base_url):
         self.base_url = base_url
+        self.session = Session()
 
     def get(self, relative_url, *args, **kwargs):
 
@@ -24,7 +25,7 @@ class DefaultHttpClient(object):
         params["source"] = "python"
         kwargs["params"] = params
 
-        resp = requests.get("{}{}".format(self.base_url, relative_url), timeout=30, *args, **kwargs)
+        resp = self.session.get("{}{}".format(self.base_url, relative_url), timeout=30, *args, **kwargs)
         if ('Is_batch' in resp.headers and resp.headers['Is_batch'] == 'true') or \
                 ('Content-Type' in resp.headers and resp.headers['Content-Type'] == 'text/csv'):
             return resp


### PR DESCRIPTION
Unless there is a better way already in place (If so, I'd be interested to know how), this PR would allow the user to have more control on the requests session: caching, rate limiter etc...

```python
from pyrate_limiter import Duration, RequestRate, Limiter
from requests_ratelimiter import LimiterMixin, SQLiteBucket
from requests_cache import CacheMixin, SQLiteCache
from requests import Session


class CachedLimiterSession(CacheMixin, LimiterMixin, Session):
    pass


session = CachedLimiterSession(
    limiter=Limiter(
        RequestRate(8, Duration.MINUTE), RequestRate(800, Duration.DAY)
    ),
    expire_after=timedelta(hours=48),
    bucket_class=SQLiteBucket,
    backend=SQLiteCache(".cache/requests.db"),
)

twelve_data_client = TDClient(apikey=TWELVEDATA_KEY)
twelve_data_client.ctx.http_client.session = session
```